### PR TITLE
A theoretical issue and extra debug

### DIFF
--- a/distros/centos7/bin-x86/run_build.sh
+++ b/distros/centos7/bin-x86/run_build.sh
@@ -58,7 +58,7 @@ fi
 
 echo "${REF}" >${OUTDIR}/REF
 
-CONFIGUREHASH=$(cat LUSTRE-VERSION-GEN $(find -name "*.m4" -o -name "*.ac") | md5sum | cut -f1 -d " ")
+CONFIGUREHASH=$(cat LUSTRE-VERSION-GEN $(find -name "*.m4" -o -name "*.ac") $(find ${KERNELDIR} -name .config) | md5sum | cut -f1 -d " ")
 log "autogen.sh"
 sh autogen.sh >>${BUILDLOG} 2>&1
 
@@ -92,6 +92,9 @@ if [ $RETVAL -ne 0 ] ; then
 	make -j8 >/dev/null 2>${OUTDIR}/build${EXTRANAME}.stderr
 	PATTERN=$(echo ${TGTBUILD}/ | sed 's/\//\\\//g')
 	grep '[[:digit:]]\+:[[:digit:]]\+: ' ${OUTDIR}/build${EXTRANAME}.stderr | sed "s/^${PATTERN}//" 1>&2 # to stdout where it can be easily separated
+	cp config.h ${OUTDIR}/config.h-${EXTRANAME}
+	cp config.log ${OUTDIR}/config.log-${EXTRANAME}
+	cp config.cache ${OUTDIR}/config.cache-${EXTRANAME}-${CONFIGUREHASH}
         exit 14
 fi
 

--- a/distros/rhel8.4/bin-x86/run_build.sh
+++ b/distros/rhel8.4/bin-x86/run_build.sh
@@ -60,7 +60,7 @@ fi
 
 echo "${REF}" >${OUTDIR}/REF
 
-CONFIGUREHASH=$(cat LUSTRE-VERSION-GEN $(find -name "*.m4" -o -name "*.ac") | md5sum | cut -f1 -d " ")
+CONFIGUREHASH=$(cat LUSTRE-VERSION-GEN $(find -name "*.m4" -o -name "*.ac") $(find ${KERNELDIR} -name .config) | md5sum | cut -f1 -d " ")
 log "autogen.sh"
 sh autogen.sh >>${BUILDLOG} 2>&1
 # See if we have cached configure runs.
@@ -93,6 +93,9 @@ if [ $RETVAL -ne 0 ] ; then
 	make -j8 >/dev/null 2>${OUTDIR}/build${EXTRANAME}.stderr
 	PATTERN=$(echo ${TGTBUILD}/ | sed 's/\//\\\//g')
 	grep '[[:digit:]]\+:[[:digit:]]\+: ' ${OUTDIR}/build${EXTRANAME}.stderr | sed "s/^${PATTERN}//" 1>&2 # to stdout where it can be easily separated
+	cp config.h ${OUTDIR}/config.h-${EXTRANAME}
+	cp config.log ${OUTDIR}/config.log-${EXTRANAME}
+	cp config.cache ${OUTDIR}/config.cache-${EXTRANAME}-${CONFIGUREHASH}
         exit 14
 fi
 

--- a/distros/rhel8.5/bin-x86/run_build.sh
+++ b/distros/rhel8.5/bin-x86/run_build.sh
@@ -57,7 +57,7 @@ fi
 
 echo "${REF}" >${OUTDIR}/REF
 
-CONFIGUREHASH=$(cat LUSTRE-VERSION-GEN $(find -name "*.m4" -o -name "*.ac") | md5sum | cut -f1 -d " ")
+CONFIGUREHASH=$(cat LUSTRE-VERSION-GEN $(find -name "*.m4" -o -name "*.ac") $(find ${KERNELDIR} -name .config) | md5sum | cut -f1 -d " ")
 log "autogen.sh"
 sh autogen.sh >>${BUILDLOG} 2>&1
 # See if we have cached configure runs.
@@ -90,6 +90,9 @@ if [ $RETVAL -ne 0 ] ; then
 	make -j8 >/dev/null 2>${OUTDIR}/build${EXTRANAME}.stderr
 	PATTERN=$(echo ${TGTBUILD}/ | sed 's/\//\\\//g')
 	grep '[[:digit:]]\+:[[:digit:]]\+: ' ${OUTDIR}/build${EXTRANAME}.stderr | sed "s/^${PATTERN}//" 1>&2 # to stdout where it can be easily separated
+	cp config.h ${OUTDIR}/config.h-${EXTRANAME}
+	cp config.log ${OUTDIR}/config.log-${EXTRANAME}
+	cp config.cache ${OUTDIR}/config.cache-${EXTRANAME}-${CONFIGUREHASH}
         exit 14
 fi
 


### PR DESCRIPTION
As a purely theoretical fix an changed kernel .config can invalidate a config.cache result.
 -  include the kernel .config in the configure hash
Extra Debugging
  copy out the config.[cache|h|log] for analysis on build failures
Signed-off-by: Shaun Tancheff <shaun.tancheff@hpe.com>